### PR TITLE
Adding more endpoints and geometry capabilities

### DIFF
--- a/application.py
+++ b/application.py
@@ -65,16 +65,17 @@ def call_matlab(d):
 
     # Default empty geometry file
     geom_file = ""
+    obj_id = 0
     obj_type = d['objectType']
     if obj_type == 'sphere':
-        obj_id = float(1)
+        obj_id = 1
     elif obj_type == 'plate':
-        obj_id = float(2)
+        obj_id = 2
     elif obj_type == 'cylinder':
-        obj_id = float(3)
+        obj_id = 3
     elif obj_type == 'custom':
         # Handle the geometry file
-        obj_id = float(4)
+        obj_id = 4
         if d['user_id'] is None:
             abort(400, "Need a valid userId with a custom objectType.")
         # The geometry file is stored in the temporary directory
@@ -82,7 +83,7 @@ def call_matlab(d):
     else:
         abort(400, "Invalid objectType")
 
-    out = eng.MAIN(obj_type, d["diameter"], d["length"],
+    out = eng.MAIN(float(obj_id), d["diameter"], d["length"],
                    d["area"], d["pitch"], d["sideslip"], d["temperature"],
                    d["speed"], composition["o"], composition["o2"],
                    composition["n2"], composition["he"], composition["h"],

--- a/application.py
+++ b/application.py
@@ -1,5 +1,36 @@
-from tempfile import NamedTemporaryFile
+"""VECTOR API
+
+This application sets up endpoints to work with the VECTOR code.
+The current VECTOR code is written in Matlab, which we connect
+to through the matlab.engine routine.
+
+Endpoints
+---------
+/geometry : POST
+    Receives a geometry file upload. We save this to a unique directory
+    in /tmp space and return the unique identifier to the frontend for
+    future requests.
+
+/geometry/sat_name : POST
+    This endpoint says we want the specific satellite's geometry file that we
+    already have locally, so no upload comes along with it. We move that
+    local geometry over to a unique directory
+    in /tmp space and return the unique identifier to the frontend for
+    future requests.
+
+/singlepoint/<id> : POST
+    Receives the json data from the frontend website and makes
+    the call to Matlab to produce the output results. It returns
+    a json dictionary of the calculated values.
+
+/image/<id> : GET
+    Returns the image that was produced by the geometry file uploaded. It
+    must have an associated <id> which is where the saved files are stored.
+"""
+import shutil
+import os
 import pprint
+import uuid
 from flask import Flask, abort, jsonify, request, send_file, make_response
 from flask_cors import CORS
 
@@ -16,12 +47,11 @@ CORS(application)
 application.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024
 ALLOWED_EXTENSIONS = {'wrl'}
 
+
 def call_matlab(d):
     """Call the matlab main routine with the input dictionary `d`."""
 
     # Used for MATLAB input file parsing
-    OBJ_TYPE_DICT = {'sphere': 1, 'plate': 2,
-                     'cylinder': 3, 'geometry_file': 4}
     ACCOM_MODEL_DICT = {'SESAM': -1, 'Fixed': 0, 'Goodman': 2}
     # Matlab doesn't like ints... So change them to floats
     for key in d:
@@ -33,12 +63,31 @@ def call_matlab(d):
         # MATLAB wants floats...
         composition[key] = float(composition[key])
 
-    out = eng.MAIN(OBJ_TYPE_DICT[d["objectType"]], d["diameter"], d["length"],
+    # Default empty geometry file
+    geom_file = ""
+    obj_type = d['objectType']
+    if obj_type == 'sphere':
+        obj_id = float(1)
+    elif obj_type == 'plate':
+        obj_id = float(2)
+    elif obj_type == 'cylinder':
+        obj_id = float(3)
+    elif obj_type == 'custom':
+        # Handle the geometry file
+        obj_id = float(4)
+        if d['user_id'] is None:
+            abort(400, "Need a valid userId with a custom objectType.")
+        # The geometry file is stored in the temporary directory
+        geom_file = '/tmp/' + d['user_id'] + '/geom.wrl'
+    else:
+        abort(400, "Invalid objectType")
+
+    out = eng.MAIN(obj_type, d["diameter"], d["length"],
                    d["area"], d["pitch"], d["sideslip"], d["temperature"],
                    d["speed"], composition["o"], composition["o2"],
                    composition["n2"], composition["he"], composition["h"],
                    ACCOM_MODEL_DICT[d["accommodationModel"]],
-                   d["energyAccommodation"], d["surfaceMass"], matlab.double([]), "",
+                   d["energyAccommodation"], d["surfaceMass"], matlab.double([]), geom_file,
                    nargout=5)
 
     # Make a dict for json return
@@ -49,24 +98,16 @@ def call_matlab(d):
     return d_return
 
 
-def call_matlab_image(fname):
-    """Call the matlab image generation function with the input filename.
-
-    Returns
-    -------
-    filepath : str
-        Path to the created image.
-    """
-    # TODO: Still need to add the calls to the actual Matlab code.
-    return 'test.png'
-
-
 @application.route('/api/singlepoint', methods=['POST'])
-def vector_matlab():
+@application.route('/api/singlepoint/<user_id>', methods=['POST'])
+def vector_matlab(user_id=None):
     if not request.json:
         abort(400, "No json content in the request.")
 
-    output = call_matlab(request.json)
+    input_dict = request.json
+    input_dict['user_id'] = user_id
+    output = call_matlab(input_dict)
+
     return jsonify(output)
 
 
@@ -75,8 +116,37 @@ def allowed_file(filename):
            filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
 
 
-@application.route('/api/image', methods=['POST'])
-def generate_image():
+@application.route('/api/geometry/<sat_name>', methods=['POST'])
+def sat_geometry(sat_name):
+    """
+    This is a locally stored geometry file. Just move it over to the
+    temporary directory unique to this user in /tmp space
+    """
+    valid_sats = {'sorce': 'sorce_simple_v0.wrl',
+                  'cubesat1u': '1ucube.wrl',
+                  'deployable3u': '3U_wdeployables.wrl'}
+
+    if sat_name not in valid_sats:
+        abort(400, f'Invalid satellite choice, it must be one of {valid_sats.keys()}.')
+
+    user_id = str(uuid.uuid4())
+    temp_dir = '/tmp/' + user_id + '/'
+    os.makedirs(temp_dir)
+    dest_file = temp_dir + 'geom.wrl'
+
+    orig_dir = '/opt/python/current/app/vector-code/CD_CODE/'
+    orig_file = orig_dir + valid_sats[sat_name]
+
+    # Copy it over to the temp directory and call it 'geom.wrl'
+    shutil.copyfile(orig_file, dest_file)
+
+    return jsonify({'userId': user_id})
+
+
+@application.route('/api/geometry', methods=['POST'])
+def save_geometry():
+    """Save the geometry file to a temporary directory."""
+
     # the file collection is lost when requests go through the API Gateway http proxy
     file = request.files.get('file') or request.environ.get('wsgi.input')
     if not file:
@@ -89,27 +159,39 @@ def generate_image():
     if file_path and not allowed_file(file_path):
         abort(400, f"Bad file extension, only '.wrl' filetypes are allowed in '{file_path}'")
 
+    # Make a directory unique to this user in /tmp space
+    user_id = str(uuid.uuid4())
+    temp_dir = '/tmp/' + user_id + '/'
+    os.makedirs(temp_dir)
+    geom_file = temp_dir + 'geom.wrl'
+
     # Save the uploaded file to a temporary file and then pass
-    # that on to the matlab image generation code
+    # that on to the Matlab image generation code
     bufsize = 16384
-    with NamedTemporaryFile() as f:
+    with open(geom_file) as f:
         # read the post data stream using a reasonable buffer size
         # the save method isn't available on the wsgi.input data stream
         data = file.read(bufsize)
         while data:
             f.write(data)
             data = file.read(bufsize)
-        
-        image_fname = call_matlab_image(f.name)
-        return send_file(image_fname, mimetype='image/png')
 
-    # If we made it here, there was an unknown error
-    abort(400, "Unknown error handling the uploaded image")
+    return jsonify({'userId': user_id})
+
+
+@application.route('/api/image/<user_id>', methods=['GET'])
+def get_image(user_id):
+    """Get the image associated with <user_id>"""
+    image_fname = '/tmp/' + user_id + '/geometry.png'
+    if not os.path.exists(image_fname):
+        abort(404, f"File not found for the userId: '{user_id}'")
+
+    return send_file(image_fname, mimetype='image/png')
 
 
 @application.errorhandler(Exception)
 def handle_error(error):
-    '''General Exception Handler'''
+    """General Exception Handler"""
     error_description = getattr(error, 'description', str(error))
     if error_description != str(error):
         error_description += "\n" + str(error)

--- a/application.py
+++ b/application.py
@@ -169,7 +169,7 @@ def save_geometry():
     # Save the uploaded file to a temporary file and then pass
     # that on to the Matlab image generation code
     bufsize = 16384
-    with open(geom_file) as f:
+    with open(geom_file, 'wb') as f:
         # read the post data stream using a reasonable buffer size
         # the save method isn't available on the wsgi.input data stream
         data = file.read(bufsize)


### PR DESCRIPTION
# New API capabilities

Changing the workflow for the frontend interactions. Added several new endpoints and a user_id that is used to store files.

* New `/api/geometry` and `/api/geometry/sat_name` endpoints.
* The old `/api/image` endpoint now requires a user_id to get the proper image back, so the call now looks like `/api/image/<uniqueId that geometry endpoint returned>`
* Calls the Matlab function with the proper geometry file for the user.

## Standard workflow

No geometry file so just submit to `/api/singlepoint`

## New workflow with geometry

1. Upload geometry file `/api/geometry`. Save the returned `userId`
2. Submit the data and run to `/api/singlepoint/userId`, which will run the case and return the data payload.
3. GET the output image if desired from `/api/image/userId`. NOTE: It is dependent on calling `/api/singlepoint/userId` first to produce the proper image.

## Questions

Is the /tmp directory OK to write to? How long will items stay there, will it overflow? We could write a cronjob to clean up the directory on a schedule or something if need be too. Or if we want to store things we can write out to an EFS or s3 bucket.